### PR TITLE
Allow authorize to pass arguments to policy methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Pundit makes the following assumptions about this class:
   you want to check. This does not need to be an ActiveRecord or even
   an ActiveModel object, it can be anything really.
 - The class implements some kind of query method, in this case `create?`.
-  Usually, this will map to the name of a particular controller action.
+  Usually, this will map to the name of a particular controller action. The
+  query method may take zero or more arguments.
 
 That's it really.
 
@@ -108,6 +109,30 @@ def publish
   authorize @post, :update?
   @post.publish!
   redirect_to @post
+end
+```
+
+Any further arguments passed to `authorize` will be passed onto the policy as
+arguments to the query method. This is most useful when the policy needs more
+information in order to make a decision. For example:
+
+``` ruby
+class PostPolicy < Struct.new(:user, :post)
+  def remove_tag?(tag)
+    record.tags.include?(tag) and record.authored_by?(user)
+  end
+end
+
+class PostsController < ApplicationController
+  include Pundit
+
+  def remove_tag
+    @post = Post.find(params[:id])
+    @tag  = @post.tags.find(params[:tag_id])
+    authorize @post, :remove_tag?, @tag
+    @post.remove_tag(@tag)
+    respond_with(@post)
+  end
 end
 ```
 

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -52,10 +52,10 @@ module Pundit
     raise NotAuthorizedError unless @_policy_scoped
   end
 
-  def authorize(record, query=nil)
+  def authorize(record, query=nil, *args)
     query ||= params[:action].to_s + "?"
     @_policy_authorized = true
-    unless policy(record).public_send(query)
+    unless policy(record).public_send(query, *args)
       raise NotAuthorizedError, "not allowed to #{query} this #{record}"
     end
     true

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -13,6 +13,9 @@ class PostPolicy < Struct.new(:user, :post)
   def show?
     true
   end
+  def known_author?(other_user)
+    true
+  end
 end
 class PostPolicy::Scope < Struct.new(:user, :scope)
   def resolve
@@ -223,6 +226,10 @@ describe Pundit do
 
     it "raises an error when the permission check fails" do
       expect { controller.authorize(Post.new) }.to raise_error(Pundit::NotAuthorizedError)
+    end
+
+    it "passes extra attributes through to policy methods" do
+      controller.authorize(post, :known_author?, OpenStruct.new).should be_true
     end
   end
 


### PR DESCRIPTION
`authorize` currently assumes that each policy has enough information to make a decision. This isn't always the case as described in the policy below.

``` ruby
class ProjectPolicy
  # Determine if user is allowed to remove other_user from the project.
  #
  # @return [Boolean]
  def remove_user?(other_user)
    user != other_user && project.owned_by?(user)
  end
end
```

`authorize` has been patched to send any extra arguments to the policy which 
makes the above possible.

``` ruby
class ProjectsController < ApplicationController
  include Pundit

   # This isn't RESTful but shows intent.
  def remove_user
    authorize project, :remove_user?, other_user

    project.remove_user other_user
    respond_with project
  end

   private

  def project
    @project ||= current_user.find_project params[:id]
  end

  def other_user
    @other_user ||= project.find_user params[:user_id]
  end
end
```