### PR TITLE
pass arbitrary arguments to #authorize

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -59,12 +59,12 @@ module Pundit
     raise AuthorizationNotPerformedError unless @_policy_scoped
   end
 
-  def authorize(record, query=nil)
+  def authorize(record, query=nil, *args)
     query ||= params[:action].to_s + "?"
     @_policy_authorized = true
 
     policy = policy(record)
-    unless policy.public_send(query)
+    unless policy.public_send(query, *args)
       error = NotAuthorizedError.new("not allowed to #{query} this #{record}")
       error.query, error.record, error.policy = query, record, policy
 

--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -3,13 +3,13 @@ module Pundit
     module Matchers
       extend ::RSpec::Matchers::DSL
 
-      matcher :permit do |user, record|
+      matcher :permit do |user, record, *args|
         match_for_should do |policy|
-          permissions.all? { |permission| policy.new(user, record).public_send(permission) }
+          permissions.all? { |permission| policy.new(user, record).public_send(permission, *args) }
         end
 
         match_for_should_not do |policy|
-          permissions.none? { |permission| policy.new(user, record).public_send(permission) }
+          permissions.none? { |permission| policy.new(user, record).public_send(permission, *args) }
         end
 
         failure_message_for_should do |policy|

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -13,6 +13,9 @@ class PostPolicy < Struct.new(:user, :post)
   def show?
     true
   end
+  def publish?(params={})
+    params[:editor]
+  end
 end
 class PostPolicy::Scope < Struct.new(:user, :scope)
   def resolve
@@ -214,6 +217,12 @@ describe Pundit do
     it "can be given a different permission to check" do
       expect(controller.authorize(post, :show?)).to be_truthy
       expect { controller.authorize(post, :destroy?) }.to raise_error(Pundit::NotAuthorizedError)
+    end
+
+    it "can be given a query and arguments" do
+      expect(controller.authorize(post, :publish?, editor: true)).to eq(true)
+      expect { controller.authorize(post, :publish?, editor: false) }.to raise_error(Pundit::NotAuthorizedError)
+      expect { controller.authorize(post, :publish?) }.to raise_error(Pundit::NotAuthorizedError)
     end
 
     it "works with anonymous class policies" do


### PR DESCRIPTION
this facilitates the usecase where an query method would want to conditionally authorize based on the content of the request parameters