### PR TITLE
Add policy_attributes helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,12 +369,14 @@ In Rails 4 (or Rails 3.2 with the
 [strong_parameters](https://github.com/rails/strong_parameters) gem),
 mass-assignment protection is handled in the controller.
 Pundit helps you permit different users to set different attributes. Don't
-forget to provide your policy an instance of object or a class so correct
-permissions could be loaded.
+forget to provide your policy an instance of object or a class so the correct policy is loaded.
 
 ```ruby
 # app/policies/post_policy.rb
 class PostPolicy < ApplicationPolicy
+
+  alias_method :post, :record
+
   def permitted_attributes
     if user.admin? || user.owner_of?(post)
       [:title, :body, :tag_list]
@@ -382,10 +384,12 @@ class PostPolicy < ApplicationPolicy
       [:tag_list]
     end
   end
+
 end
 
 # app/controllers/posts_controller.rb
 class PostsController < ApplicationController
+
   def update
     @post = Post.find(params[:id])
     if @post.update(post_params)
@@ -398,8 +402,9 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(*policy(@post || Post).permitted_attributes)
+    params.require(:post).permit(*policy_attributes(@post || :post))
   end
+
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,9 @@ In Rails 4 (or Rails 3.2 with the
 [strong_parameters](https://github.com/rails/strong_parameters) gem),
 mass-assignment protection is handled in the controller.
 Pundit helps you permit different users to set different attributes. Don't
-forget to provide your policy an instance of object or a class so the correct policy is loaded.
+forget to provide your policy an instance of object or a class so the correct 
+policy is loaded. Alternatively, you can pass in a symbol identifying the
+policy to be loaded.
 
 ```ruby
 # app/policies/post_policy.rb

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -32,12 +32,22 @@ module Pundit
     def policy!(user, record)
       PolicyFinder.new(record).policy!.new(user, record)
     end
+
+    def policy_attributes!(user, record)
+      policy = policy!(user, record)
+      if policy.respond_to?(:permitted_attributes)
+        policy.permitted_attributes
+      else
+        raise NotDefinedError, "expected #{policy} to respond to #permitted_attributes"
+      end
+    end
   end
 
   included do
     if respond_to?(:helper_method)
       helper_method :policy_scope
       helper_method :policy
+      helper_method :policy_attributes
       helper_method :pundit_user
     end
     if respond_to?(:hide_action)
@@ -45,6 +55,8 @@ module Pundit
       hide_action :policy_scope=
       hide_action :policy
       hide_action :policy=
+      hide_action :policy_attributes
+      hide_action :policy_attributes=
       hide_action :authorize
       hide_action :verify_authorized
       hide_action :verify_policy_scoped
@@ -85,6 +97,11 @@ module Pundit
     @policy or Pundit.policy!(pundit_user, record)
   end
   attr_writer :policy
+
+  def policy_attributes(record)
+    @policy_attributes or Pundit.policy_attributes!(pundit_user, record)
+  end
+  attr_writer :policy_attributes
 
   def pundit_user
     current_user

--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -40,6 +40,8 @@ module Pundit
           object.model_name
         elsif object.class.respond_to?(:model_name)
           object.class.model_name
+        elsif object.is_a?(Symbol)
+          object.to_s.classify
         elsif object.is_a?(Class)
           object
         else

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -220,4 +220,20 @@ describe Pundit do
       expect(controller.policy_scope(post)).to eq new_scope
     end
   end
+
+  describe ".policy_attributes" do
+    it "returns the permitted attributes" do
+      expect(controller.policy_attributes(:post)).to eq ['title']
+      expect(controller.policy_attributes(post)).to eq ['title']
+      expect(controller.policy_attributes(Post)).to eq ['title']
+    end
+
+    it "throws an exception if the given policy can't be found" do
+      expect { controller.policy_attributes(:article) }.to raise_error(Pundit::NotDefinedError)
+    end
+
+    it "throws an exception if the given policy doesn't respond to #permitted_attributes" do
+      expect { controller.policy_attributes(:blog) }.to raise_error(Pundit::NotDefinedError)
+    end
+  end
 end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -66,6 +66,12 @@ describe Pundit do
       expect(policy.comment).to eq Comment
     end
 
+    it "returns an instantiated policy given a symbol" do
+      policy = Pundit.policy(user, :dashboard)
+      expect(policy.class).to eq DashboardPolicy
+      expect(policy.user).to eq user
+    end
+
     it "returns nil if the given policy can't be found" do
       expect(Pundit.policy(user, article)).to be_nil
       expect(Pundit.policy(user, Article)).to be_nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,7 +59,4 @@ class ArticleTag
 end
 
 class DashboardPolicy < Struct.new(:user, :dashboard)
-  def show?
-    true
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@ class PostPolicy < Struct.new(:user, :post)
   def show?
     true
   end
+  def permitted_attributes
+    ['title']
+  end
 end
 class PostPolicy::Scope < Struct.new(:user, :scope)
   def resolve

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,3 +57,9 @@ class ArticleTag
     end
   end
 end
+
+class DashboardPolicy < Struct.new(:user, :dashboard)
+  def show?
+    true
+  end
+end


### PR DESCRIPTION
This PR adds a `policy_attributes` helper. It wraps the current approach (of encouraging `PostPolicy#permitted_attributes` to return accessible attributes).

```ruby
def post_params
  params.require(:post).permit(*policy_attributes(@post || :post))
end
```

If you don't need the model to decide which attributes are permitted, it gets even shorter:
```ruby
def post_params
  params.require(:post).permit(*policy_attributes(:post))
end
```

I've tried wrapping things even further and returning some kind of strong params object, however this seems to be cleanest and nicest approach without bloating Pundit too much.

One "side effect" is that you can also pass policies as symbols, which allows policies without underlying models as suggested in #77: `authorize :dashboard, :show? # => DashboardPolicy#show?`

@jnicklas I'd highly value your opinion.