### PR TITLE
Use record#inspect in NotAuthorizedError message.

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -9,6 +9,10 @@ require "active_support/dependencies/autoload"
 module Pundit
   class NotAuthorizedError < StandardError
     attr_accessor :query, :record, :policy
+
+    def to_s
+      "not allowed to '#{query}' this #{record.inspect}"
+    end
   end
   class AuthorizationNotPerformedError < StandardError; end
   class PolicyScopingNotPerformedError < AuthorizationNotPerformedError; end
@@ -68,7 +72,7 @@ module Pundit
 
     policy = policy(record)
     unless policy.public_send(query)
-      error = NotAuthorizedError.new("not allowed to #{query} this #{record}")
+      error = NotAuthorizedError.new
       error.query, error.record, error.policy = query, record, policy
 
       raise error

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -181,7 +181,11 @@ describe Pundit do
     end
 
     it "raises an error when the permission check fails" do
-      expect { controller.authorize(Post.new) }.to raise_error(Pundit::NotAuthorizedError)
+      klass = Pundit::NotAuthorizedError
+      message= /not allowed to 'eat' this #<Stringy:0x[^ ]* @string="taco">/
+      object = Stringy.new("taco")
+
+      expect { controller.authorize(object, :eat) }.to raise_error(klass, message)
     end
 
     it "raises an error with a query and action" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,6 +85,23 @@ end
 
 class DashboardPolicy < Struct.new(:user, :dashboard); end
 
+class StringyPolicy
+  def initialize(*)
+  end
+  def method_missing(*)
+    false
+  end
+end
+
+class Stringy
+  def initialize(string)
+    @string = string
+  end
+  def to_s
+    @string
+  end
+end
+
 class Controller
   include Pundit
 


### PR DESCRIPTION
Hello,

I introduced pundit into an application a few months ago and most everything went well but I had a small hiccup with some ActiveRecord models that defined a `#to_s` method. Most of them returned user input for these, which ranged from benign but unhelpful printing of input instead of an object description, to bad when there was logic that failed in the method. Here is a script to demonstrate the problem:

```
# gem install rails sqlite3
gem 'rails', '~> 4'
require 'active_record'
require 'pundit'

ActiveRecord::Base.establish_connection(adapter:'sqlite3',database: ':memory:')

ActiveRecord::Migration.verbose = false

ActiveRecord::Schema.define do
  create_table :tacos, :force => true do |t|
    t.string :name
    t.string :flavor
  end

  create_table :burritos, :force => true do |t|
    t.string :name
  end
end

class Taco < ActiveRecord::Base
  def to_s
    name
  end
end

class Burrito < ActiveRecord::Base
  def to_s
    name[0,10]
  end
end

class Denier
  include Pundit
  def initialize(*)
  end

  def policy(*)
    self
  end

  def method_missing(*)
    false
  end
end

def eat thing
  Denier.new.authorize thing, 'eat'
rescue => e
  puts "#{e.class}: #{e}"
end

eat Taco.new(name: 'Doritos Locos', flavor: 'Cool ranch')
eat Burrito.new
```

When I run this script on master, I get this output:

```
Pundit::NotAuthorizedError: not allowed to eat this Doritos Locos
NoMethodError: undefined method `[]' for nil:NilClass
```

When I run the script on this PR's branch, I get this output:

```
Pundit::NotAuthorizedError: not allowed to 'eat' this #<Taco id: nil, name: "Doritos Locos", flavor: "Cool ranch">
Pundit::NotAuthorizedError: not allowed to 'eat' this #<Burrito id: nil, name: nil>
```

I was curious if there was an accepted Ruby style for using `to_s` vs. `inspect`, since I wasn't sure if the problem was in pundit or this application. After searching for a few minutes, I found [this reference](http://books.google.com/books?id=jcUbTcr5XWwC&pg=PA80&lpg=PA80&dq=ruby+to_s+vs+inspect&source=bl&ots=fJApsi5rhH&sig=i37KBlQy9SP-zGpg3vyQxZ3NrrU&hl=en&sa=X&ei=dpT-U8CMO86BygSz9oKIDQ&ved=0CGQQ6AEwCA#v=onepage&q&f=false) ([imgur mirror](http://i.imgur.com/PZ4QhBb.png)) in The Ruby Programming Language by David Flanagan and Yukihiro Matsumoto:

> `to_s` is generally intended to return a human-readable representation of the object, suitable for end users. `inspect`, on the other hand, is intended for debugging use, and should return a representation that is helpful to Ruby developers.

Thanks very much for your work on this gem, I really enjoy using it!