### PR TITLE
change policy finder find order

### DIFF
--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -36,10 +36,11 @@ module Pundit
       elsif object.class.respond_to?(:policy_class)
         object.class.policy_class
       else
-        klass = if object.respond_to?(:model_name)
-          object.model_name
-        elsif object.class.respond_to?(:model_name)
+        klass = if object.class.respond_to?(:model_name)
           object.class.model_name
+        elsif object.respond_to?(:model_name)
+          object.model_name
+
         elsif object.is_a?(Class)
           object
         elsif object.is_a?(Symbol)


### PR DESCRIPTION
I worked in a legacy app and sadly it has a model which has `model_name` as an attribute. I find it less likely that a class `model_name` is overwritten, that's why I propose this change in the find order.