### PR TITLE
Add array-based syntax for namespaced headless policies

### DIFF
--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -44,6 +44,8 @@ module Pundit
           object
         elsif object.is_a?(Symbol)
           object.to_s.classify
+        elsif object.is_a?(Array)
+          object.map(&:to_s).join('/').to_s.classify
         else
           object.class
         end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -102,6 +102,13 @@ describe Pundit do
         expect(policy.user).to eq user
         expect(policy.dashboard).to eq :dashboard
       end
+
+      it "returns an instantiated policy given an array" do
+        policy = Pundit.policy(user, [:project, :dashboard])
+        expect(policy.class).to eq Project::DashboardPolicy
+        expect(policy.user).to eq user
+        expect(policy.dashboard).to eq [:project, :dashboard]
+      end
     end
   end
 
@@ -135,6 +142,13 @@ describe Pundit do
       expect(policy.class).to eq DashboardPolicy
       expect(policy.user).to eq user
       expect(policy.dashboard).to eq :dashboard
+    end
+
+    it "returns an instantiated policy given an array" do
+      policy = Pundit.policy!(user, [:project, :dashboard])
+      expect(policy.class).to eq Project::DashboardPolicy
+      expect(policy.user).to eq user
+      expect(policy.dashboard).to eq [:project, :dashboard]
     end
 
     it "throws an exception if the given policy can't be found" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,6 +85,10 @@ end
 
 class DashboardPolicy < Struct.new(:user, :dashboard); end
 
+module Project
+  class DashboardPolicy < Struct.new(:user, :dashboard); end
+end
+
 class Controller
   include Pundit
 


### PR DESCRIPTION
Before to namespace headless policy we needed to use following syntax:
```
authorize :'project/dashboard'
```

Now we can use array to specify each constant separately so it looks cleaner
```
authorize [:project, :dashboard]
```