### PR TITLE
More informative error messages for multi permission checks checks.

### DIFF
--- a/lib/pundit/rspec.rb
+++ b/lib/pundit/rspec.rb
@@ -23,7 +23,7 @@ module Pundit
 
         failure_message_when_negated_proc = lambda do |policy|
           was_were = @violating_permissions.count > 1 ? "were" : "was"
-          "Expected #{policy} to grant #{permissions.to_sentence} on #{record} but #{@violating_permissions.to_sentence} #{was_were} granted"
+          "Expected #{policy} not to grant #{permissions.to_sentence} on #{record} but #{@violating_permissions.to_sentence} #{was_were} granted"
         end
 
         if respond_to?(:match_when_negated)


### PR DESCRIPTION
So, what I was thinking was something like this. Could maybe revert to the original behaviour when there's only one permission, 'cos then repeating the sole violators name is then futile. What do you think?