### PR TITLE
Add `#skip_authorization` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,22 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+If you're using `verify_authorized` in your controllers but need to
+conditionally bypass verification, you can use `skip_authorization`. This is
+useful in circumstances where you don't want to disable verification for the
+entire action, but have some cases where you intend to not authorize.
+
+```ruby
+def show
+  record = Record.find_by(attribute: "value")
+  if record.present?
+    authorize record
+  else
+    skip_authorization
+  end
+end
+```
+
 ## Scopes
 
 Often, you will want to have some kind of view listing records which a

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -77,6 +77,10 @@ module Pundit
     true
   end
 
+  def skip_authorization
+    @_pundit_policy_authorized = true
+  end
+
   def policy_scope(scope)
     @_pundit_policy_scoped = true
     policy_scopes[scope] ||= Pundit.policy_scope!(pundit_user, scope)

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -193,6 +193,13 @@ describe Pundit do
     end
   end
 
+  describe "#skip_authorization" do
+    it "disables authorization verification" do
+      controller.skip_authorization
+      expect { controller.verify_authorized }.not_to raise_error
+    end
+  end
+
   describe "#pundit_user" do
     it 'returns the same thing as current_user' do
       expect(controller.pundit_user).to eq controller.current_user


### PR DESCRIPTION
Allows users to skip authorization and prevent exceptions that result from
having `#verify_authorized` enabled. There are some times when you'd only
conditionally want to skip authorization, but you still want to keep
verification enabled for that action.

An example:
```ruby
def show
  record = Record.find_by(attribute: "value")
  if record.present?
    authorize record
  else
    skip_authorization
  end
end
```