### PR TITLE
Fix tests on activesupport v4.2.0

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,8 @@
-require "active_support/core_ext/kernel"
-
-warnings = capture(:stderr) do
-  require "pundit"
-  require "pundit/rspec"
-end
-
-unless warnings.to_s.empty?
-  puts "ERROR: Encountered deprecation warning!"
-  puts warnings
-  exit 1
-end
+require "pundit"
+require "pundit/rspec"
 
 require "pry"
+require "active_support"
 require "active_support/core_ext"
 require "active_model/naming"
 


### PR DESCRIPTION
`ActiveSupport` v4.2.0 deprecated `Kernel#capture` and uses
`ActiveSupport::Deprecation` to notify the user. Since spec_helper.rb
doesn't require "active_support" to setup autoloading, or
"active_support/deprecation" directly, this causes the call to `capture`
to fail. Since `Kernel#capture` is deprecated, copy (and loosely modify)
it's implementation.

Adding `require "active_support"` is still required to handle additional
uses of `ActiveSupport::Deprecation` in the rest of the library when
requiring `active_support/core_ext`.

Open to any feedback / desired changes.