### PR TITLE
Add `pundit_policy_authorized?` and `pundit_policy_scoped?` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Caches policy scopes and policies.
 - Explicitly setting the policy for the controller via `controller.policy = foo` has been removed. Instead use `controller.policies[record] = foo`.
 - Explicitly setting the policy scope for the controller via `controller.policy_policy = foo` has been removed. Instead use `controller.policy_scopes[scope] = foo`.
+- Add `pundit_policy_authorized?` and `pundit_policy_scoped?` methods.
 
 ## 0.3.0 (2014-08-22)
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ end
 ```
 
 Likewise, Pundit also adds `verify_policy_scoped` to your controller.  This
-will raise an exception in the vein of `verify_authorized`.  However it tracks
+will raise an exception in the vein of `verify_authorized`.  However, it tracks
 if `policy_scope` is used instead of `authorize`.  This is mostly useful for
 controller actions like `index` which find collections with a scope and don't
 authorize individual instances.
@@ -203,6 +203,11 @@ def show
   end
 end
 ```
+
+If you need to perform some more sophisticated logic or you want to raise a custom
+exception you can use the two lower level methods `pundit_policy_authorized?`
+and `pundit_policy_scoped?` which return `true` or `false` depending on whether
+`authorize` or `policy_scope` have been called, respectively.
 
 ## Scopes
 

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -84,12 +84,20 @@ module Pundit
     end
   end
 
+  def pundit_policy_authorized?
+    !!@_pundit_policy_authorized
+  end
+
+  def pundit_policy_scoped?
+    !!@_pundit_policy_scoped
+  end
+
   def verify_authorized
-    raise AuthorizationNotPerformedError unless @_pundit_policy_authorized
+    raise AuthorizationNotPerformedError unless pundit_policy_authorized?
   end
 
   def verify_policy_scoped
-    raise PolicyScopingNotPerformedError unless @_pundit_policy_scoped
+    raise PolicyScopingNotPerformedError unless pundit_policy_scoped?
   end
 
   def authorize(record, query=nil)

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -224,6 +224,28 @@ describe Pundit do
     end
   end
 
+  describe "#pundit_policy_authorized?" do
+    it "is true when authorized" do
+      controller.authorize(post)
+      expect(controller.pundit_policy_authorized?).to be true
+    end
+
+    it "is false when not authorized" do
+      expect(controller.pundit_policy_authorized?).to be false
+    end
+  end
+
+  describe "#pundit_policy_scoped?" do
+    it "is true when policy_scope is used" do
+      controller.policy_scope(Post)
+      expect(controller.pundit_policy_scoped?).to be true
+    end
+
+    it "is false when policy scope is not used" do
+      expect(controller.pundit_policy_scoped?).to be false
+    end
+  end
+
   describe "#authorize" do
     it "infers the policy name and authorizes based on it" do
       expect(controller.authorize(post)).to be_truthy


### PR DESCRIPTION
In some cases we might need to simply check if `authorize` or
`policy_scope` were called, without immediately raising and exception.
In other cases we might be happy if either was called and only want
to raise if neither was called.

All those edge cases are most easily served by exposing lower level
function which just perform the checks and return `true` or `false`.

The `verify_*` methods can then build on top of them to offer a
convenient path for the most common use cases.

In my particular use case I am using pundit in a grape api application and the endpoints are not named like in a classical rails application so I can't simply use `verify_policy_scoped` on `index` actions and `verify_authorized` on other actions. What I really want to check is that either one was used because I the endpoints have very few lines of code and I just want to make it impossible to forget to use pundit policy altogether. Right now, I can't do that without relying on internal instance variables which could change with next pundit release. This PR fixes that. 