### PR TITLE
Don't even look at model_name

### DIFF
--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -40,11 +40,7 @@ module Pundit
       elsif object.class.respond_to?(:policy_class)
         object.class.policy_class
       else
-        klass = if object.respond_to?(:model_name)
-          object.model_name
-        elsif object.class.respond_to?(:model_name)
-          object.class.model_name
-        elsif object.is_a?(Class)
+        klass = if object.is_a?(Class)
           object
         elsif object.is_a?(Symbol)
           object.to_s.classify


### PR DESCRIPTION
I was always under the impression that model_name's different variants (singular/plural etc...) are configurable, but this appears to not be the case. They simply delegate to the inflector. As such, there's really no point in having special cases for these. Tests still pass without this code.