### PR TITLE
Add controller helpers which facilitate update and build patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,49 @@ class PostsController < ApplicationController
 end
 ```
 
+## Controller helpers
+
+Pundit provides controller helpers which take the permitted attributes pattern to its
+logical conclusion. We can write an update action like this:
+
+```ruby
+# app/controllers/posts_controller.rb
+class PostsController < ApplicationController
+  def update
+    @post = Post.find(params[:id])
+    if update(@post)
+      redirect_to @post
+    else
+      render :edit
+    end
+  end
+end
+```
+
+Not only does this correctly retrieve the permitted attributes and assign them,
+it also makes sure authorization is performed both before *and* after we set
+these attributes. For example, an admin might be able to assign everyone a
+particular task, but a regular user can only assign themselves, not someone
+else. This kind of scenario requires the permissions to be checked twice, both
+before (they can't edit tasks assigned to someone else) and after (they can't
+assign a task to someone other than themselves).
+
+Similarly there is a helper for building a new record:
+
+```ruby
+# app/controllers/posts_controller.rb
+class PostsController < ApplicationController
+  def update
+    @post = build(Post)
+    if @post.save
+      redirect_to @post
+    else
+      render :edit
+    end
+  end
+end
+```
+
 ## RSpec
 
 ### Policy Specs

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -121,6 +121,20 @@ module Pundit
     params.require(name).permit(policy(record).permitted_attributes)
   end
 
+  def build(klass, attributes = {})
+    record = klass.build(attributes)
+    record.assign_attributes(permitted_attributes(record))
+    authorize(record)
+    record
+  end
+
+  def update(record, attributes = {})
+    authorize(record)
+    record.assign_attributes(attributes.merge(permitted_attributes(record)))
+    authorize(record)
+    record.save
+  end
+
   def policies
     @_pundit_policies ||= {}
   end

--- a/spec/policies/post_policy_spec.rb
+++ b/spec/policies/post_policy_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 describe PostPolicy do
   let(:user) { double }
-  let(:own_post) { double(user: user) }
-  let(:other_post) { double(user: double) }
+  let(:own_post) { double(user: user, votes: 0) }
+  let(:other_post) { double(user: double, votes: 0) }
   subject { described_class }
 
   permissions :update?, :show? do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ end
 
 class PostPolicy < Struct.new(:user, :post)
   def update?
-    post.user == user
+    post.user == user and post.votes < 10
   end
   def destroy?
     false
@@ -43,15 +43,37 @@ class PostPolicy < Struct.new(:user, :post)
     end
   end
 end
+
 class PostPolicy::Scope < Struct.new(:user, :scope)
   def resolve
     scope.published
   end
 end
+
 class Post < Struct.new(:user)
+  attr_reader :attributes
+  singleton_class.send :alias_method, :build, :new
+
   def self.published
     :published
   end
+
+  def initialize(attributes = {})
+    @attributes = attributes
+  end
+
+  def user
+    @attributes[:user]
+  end
+
+  def votes
+    @attributes[:votes].to_i
+  end
+
+  def assign_attributes(attributes)
+    @attributes.merge!(attributes)
+  end
+
   def to_s; "Post"; end
   def inspect; "#<Post>"; end
 end


### PR DESCRIPTION
I had this idea that if #261 is merged, we would have a lot of code which looks like this:

```ruby
@post = Post.find(params[:id])
if @post.update_attributes(permitted_attributes(@post))
  redirect_to @post
else
  render :edit
end
```

Wouldn't it be nice if we could cut down on this noise?

```ruby
@post = Post.find(params[:id])
if update(@post)
  redirect_to @post
else
  render :edit
end
```

That looks much nicer, and makes our controllers a lot cleaner. We can also handle strange edge cases where it's unclear whether authorization should be performed before or after attributes are assigned by simply doing both.

I'm unsure if this is actually a good idea. It significantly expands how involved Pundit becomes in your application. Suddenly Pundit is not part of your controller actions, but rather actions are written in Pundit-style. This is one aspect I really *disliked* about CanCan, its `find_and_authorize` helpers just started to smell too much of `InheritedResources` or `ResourceController`, both of which I've been badly burned by. Is Pundit overstepping its bounds here, or is this inline with the kind of convenience we want to provide our users?

Also this PR does not (yet?) add separate `permitted_attributes` methods for `build` and `update`. IMO it should be possible to customize these individually. This is something we should do.