### PR TITLE
all Punit errors extend Punit::Error

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -9,7 +9,8 @@ require "active_support/dependencies/autoload"
 module Pundit
   SUFFIX = "Policy"
 
-  class NotAuthorizedError < StandardError
+  class Error < StandardError; end
+  class NotAuthorizedError < Error
     attr_reader :query, :record, :policy
 
     def initialize(options = {})
@@ -22,9 +23,9 @@ module Pundit
       super(message)
     end
   end
-  class AuthorizationNotPerformedError < StandardError; end
+  class AuthorizationNotPerformedError < Error; end
   class PolicyScopingNotPerformedError < AuthorizationNotPerformedError; end
-  class NotDefinedError < StandardError; end
+  class NotDefinedError < Error; end
 
   extend ActiveSupport::Concern
 


### PR DESCRIPTION
The reason behind this is because it would make it easier for users to rescue all errors from Punit using `rescue Punit::Error`

Please let me know if you think this is a bad idea. Personally, I have `rescue Pundit::NotAuthorizedError, Pundit::AuthorizationNotPerformedError` littered in my code whenever I want to rescue from StandardError but not any errors from Punit.