### PR TITLE
Add #skip_authorization helper_method

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -70,6 +70,7 @@ module Pundit
       helper_method :policy
       helper_method :pundit_policy_scope
       helper_method :pundit_user
+      helper_method :skip_authorization
     end
     if respond_to?(:hide_action)
       hide_action :policy


### PR DESCRIPTION
The recently-added `#skip_authorization` method was not added as a helper, meaning the method is unavailable within Rails Controllers.

![screenshot](https://s3.amazonaws.com/kurtzkloud.com/ss/Screen_Shot_2015-04-09_at_15.41.02.png)

There aren't any existing tests around these `helper_method` calls, so I followed convention and didn't try to rig anything up. Let me know though if you'd like me to add a tests to cover this. 