### PR TITLE
Readme Update: NotAuthorizedError.initialize expects a hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ got through. This way you can fail more gracefully.
 ``` ruby
 class ApplicationPolicy
   def initialize(user, record)
-    raise Pundit::NotAuthorizedError, "must be logged in" unless user
+    raise Pundit::NotAuthorizedError, message: "must be logged in" unless user
     @user = user
     @record = record
   end


### PR DESCRIPTION
Please correct me if i did not understand something right, but I think i've found a mistake in your Readme.md: when initializing a NotAuthorizedError with just a string (like your Readme suggests) it will fail: 

    irb(main):001:0> raise Pundit::NotAuthorizedError, "must be logged in"
    TypeError: no implicit conversion of Symbol into Integer
	    from /Users/srecnig/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pundit-1.0.0/lib/pundit.rb:17:in `[]'
	    from /Users/srecnig/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pundit-1.0.0/lib/pundit.rb:17:in `initialize'
	from (irb):1

vs

    irb(main):010:0> raise Pundit::NotAuthorizedError, message: "must be logged in"
    Pundit::NotAuthorizedError: must be logged in
