### PR TITLE
NotAuthorizedError can be initialized with a string

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -14,11 +14,15 @@ module Pundit
     attr_reader :query, :record, :policy
 
     def initialize(options = {})
-      @query  = options[:query]
-      @record = options[:record]
-      @policy = options[:policy]
+      if options.is_a? String
+        message = options
+      else
+        @query  = options[:query]
+        @record = options[:record]
+        @policy = options[:policy]
 
-      message = options.fetch(:message) { "not allowed to #{query} this #{record.inspect}" }
+        message = options.fetch(:message) { "not allowed to #{query} this #{record.inspect}" }
+      end
 
       super(message)
     end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -344,4 +344,11 @@ describe Pundit do
       expect(Controller.new(double, params).permitted_attributes(post)).to eq({ 'votes' => 5 })
     end
   end
+
+  describe "Pundit::NotAuthorizedError" do
+    it "can be initialized with a string as message" do
+      error = Pundit::NotAuthorizedError.new("must be logged in")
+      expect(error.message).to eq "must be logged in"
+    end
+  end
 end


### PR DESCRIPTION
Like described in Readme.md, one should be able to initialize Pundit::NotAuthorizedError with a message string. See also: https://github.com/elabs/pundit/pull/277