### PR TITLE
Fixes unexpected symbol-to-policy resolution described in #280

### DIFF
--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -47,18 +47,14 @@ module Pundit
         elsif object.is_a?(Class)
           object
         elsif object.is_a?(Symbol)
-          classify(object)
+          object.to_s.camelize
         elsif object.is_a?(Array)
-          classify(object.join('/'))
+          object.join('/').camelize
         else
           object.class
         end
         "#{klass}#{SUFFIX}"
       end
-    end
-
-    def classify(name)
-      name.to_s.sub(/.*\./, '').camelize
     end
   end
 end

--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -47,14 +47,18 @@ module Pundit
         elsif object.is_a?(Class)
           object
         elsif object.is_a?(Symbol)
-          object.to_s.classify
+          classify(object)
         elsif object.is_a?(Array)
-          object.join('/').to_s.classify
+          classify(object.join('/'))
         else
           object.class
         end
         "#{klass}#{SUFFIX}"
       end
+    end
+
+    def classify(name)
+      name.to_s.sub(/.*\./, '').camelize
     end
   end
 end

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -138,17 +138,17 @@ describe Pundit do
       end
 
       it "returns an instantiated policy given a symbol" do
-        policy = Pundit.policy(user, :dashboard)
-        expect(policy.class).to eq DashboardPolicy
+        policy = Pundit.policy(user, :criteria)
+        expect(policy.class).to eq CriteriaPolicy
         expect(policy.user).to eq user
-        expect(policy.dashboard).to eq :dashboard
+        expect(policy.criteria).to eq :criteria
       end
 
       it "returns an instantiated policy given an array" do
-        policy = Pundit.policy(user, [:project, :dashboard])
-        expect(policy.class).to eq Project::DashboardPolicy
+        policy = Pundit.policy(user, [:project, :criteria])
+        expect(policy.class).to eq Project::CriteriaPolicy
         expect(policy.user).to eq user
-        expect(policy.dashboard).to eq [:project, :dashboard]
+        expect(policy.criteria).to eq [:project, :criteria]
       end
     end
   end
@@ -179,17 +179,17 @@ describe Pundit do
     end
 
     it "returns an instantiated policy given a symbol" do
-      policy = Pundit.policy!(user, :dashboard)
-      expect(policy.class).to eq DashboardPolicy
+      policy = Pundit.policy!(user, :criteria)
+      expect(policy.class).to eq CriteriaPolicy
       expect(policy.user).to eq user
-      expect(policy.dashboard).to eq :dashboard
+      expect(policy.criteria).to eq :criteria
     end
 
     it "returns an instantiated policy given an array" do
-      policy = Pundit.policy!(user, [:project, :dashboard])
-      expect(policy.class).to eq Project::DashboardPolicy
+      policy = Pundit.policy!(user, [:project, :criteria])
+      expect(policy.class).to eq Project::CriteriaPolicy
       expect(policy.user).to eq user
-      expect(policy.dashboard).to eq [:project, :dashboard]
+      expect(policy.criteria).to eq [:project, :criteria]
     end
 
     it "throws an exception if the given policy can't be found" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,10 +93,10 @@ class ArticleTag
   end
 end
 
-class DashboardPolicy < Struct.new(:user, :dashboard); end
+class CriteriaPolicy < Struct.new(:user, :criteria); end
 
 module Project
-  class DashboardPolicy < Struct.new(:user, :dashboard); end
+  class CriteriaPolicy < Struct.new(:user, :criteria); end
 end
 
 class DenierPolicy < Struct.new(:user, :record)


### PR DESCRIPTION
When attempting to find a [headless policy](https://github.com/elabs/pundit#headless-policies), I think it would be better **not** to run the symbol through Rails' `classify` because the inflector singularizes the string.

Given some `CriteriaPolicy` and `PanelPolicy`, I think its better for the following behavior

```
Policy.find!(:criteria) #=> CriteriaPolicy
Policy.find!(:panel)    #=> PanelPolicy
Policy.find!(:panels)   #=> Pundit::NotDefinedError
```

instead of the current behavior

```
Policy.find!(:criteria) #=> Pundit::NotDefinedError (couldn't find a CriteriumPolicy class)
Policy.find!(:panel)    #=> PanelPolicy
Policy.find!(:panels)   #=> PanelPolicy
```

I'd prefer the symbol passed to Pundit to be cast to a string and camel-cased, but **not** singularized.