### PR TITLE
Update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ got through. This way you can fail more gracefully.
 ``` ruby
 class ApplicationPolicy
   def initialize(user, record)
-    raise Pundit::NotAuthorizedError, "must be logged in" unless user
+    raise Pundit::NotAuthorizedError, message: "must be logged in" unless user
     @user = user
     @record = record
   end


### PR DESCRIPTION
This change just updates the README with working code when calling `raise` or `fail` with a `Pundit::NotAuthorizedError` to supply the message as a hash

The old example code threw a `TypeConversionError` when using Pundit 1.0.0.

