### PR TITLE
Try convert record #to_model in case we got decorated record

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -32,6 +32,7 @@ module Pundit
   class NotDefinedError < Error; end
 
   extend ActiveSupport::Concern
+  extend ActionView::ModelNaming
 
   class << self
     def authorize(user, record, query)
@@ -55,11 +56,11 @@ module Pundit
 
     def policy(user, record)
       policy = PolicyFinder.new(record).policy
-      policy.new(user, record) if policy
+      policy.new(user, convert_to_model(record)) if policy
     end
 
     def policy!(user, record)
-      PolicyFinder.new(record).policy!.new(user, record)
+      PolicyFinder.new(record).policy!.new(user, convert_to_model(record))
     end
   end
 

--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -1,9 +1,13 @@
+require "action_view/model_naming"
+
 module Pundit
   class PolicyFinder
+    include ActionView::ModelNaming
+
     attr_reader :object
 
     def initialize(object)
-      @object = object
+      @object = convert_to_model(object)
     end
 
     def scope

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -10,6 +10,7 @@ describe Pundit do
   let(:article_tag) { ArticleTag.new }
   let(:comments_relation) { CommentsRelation.new }
   let(:empty_comments_relation) { CommentsRelation.new(true) }
+  let(:decorated_comment) { DecoratedComment.new(comment) }
 
   describe ".authorize" do
     it "infers the policy and authorizes based on it" do
@@ -108,6 +109,18 @@ describe Pundit do
       expect(Pundit.policy(user, Article)).to be_nil
     end
 
+    it "returns an instantiated policy given an decorated model instance" do
+      policy = Pundit.policy(user, decorated_comment)
+      expect(policy.user).to eq user
+      expect(policy.comment).to eq comment
+    end
+
+    it "returns an instantiated policy given an decorated model class" do
+      policy = Pundit.policy(user, DecoratedComment)
+      expect(policy.user).to eq user
+      expect(policy.comment).to eq DecoratedComment
+    end
+
     it "returns nil if the given policy is nil" do
       expect(Pundit.policy(user, nil)).to be_nil
     end
@@ -170,6 +183,18 @@ describe Pundit do
       policy = Pundit.policy!(user, Post)
       expect(policy.user).to eq user
       expect(policy.post).to eq Post
+    end
+
+    it "returns an instantiated policy given an decorated model instance" do
+      policy = Pundit.policy!(user, decorated_comment)
+      expect(policy.user).to eq user
+      expect(policy.comment).to eq comment
+    end
+
+    it "returns an instantiated policy given an decorated model class" do
+      policy = Pundit.policy!(user, DecoratedComment)
+      expect(policy.user).to eq user
+      expect(policy.comment).to eq DecoratedComment
     end
 
     it "returns an instantiated policy given an active model class" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,6 +71,16 @@ class CommentsRelation
   def model_name; Comment.model_name; end
 end
 
+class DecoratedComment < Struct.new(:record)
+  def self.model_name
+    Comment.model_name
+  end
+
+  def to_model
+    record
+  end
+end
+
 class Article; end
 
 class BlogPolicy < Struct.new(:user, :blog); end


### PR DESCRIPTION
In case we use decorated (presenter) object when passing to `policy` helper we should try convert in to model.