### PR TITLE
Add option for permitted_attributes to not require a root node.

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,28 @@ class PostsController < ApplicationController
 end
 ```
 
+It is a Rails convention to require the outer object tag when permitting attributes, like so:
+
+```ruby
+params.require( :post ).permit( :title )
+```
+
+This is not desired in some instances, and can be omitted with the inclusion of the `no_root` option:
+
+```ruby
+# app/controllers/posts_controller.rb
+class PostsController < ApplicationController
+  def update
+    @post = Post.find(params[:id])
+    if @post.update_attributes(permitted_attributes(@post, no_root: true))
+      redirect_to @post
+    else
+      render :edit
+    end
+  end
+end
+```
+
 ## RSpec
 
 ### Policy Specs

--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -139,9 +139,14 @@ module Pundit
     policies[record] ||= Pundit.policy!(pundit_user, record)
   end
 
-  def permitted_attributes(record)
+  def permitted_attributes(record, options = {})
     name = record.class.to_s.demodulize.underscore
-    params.require(name).permit(*policy(record).permitted_attributes)
+
+    if options[:no_root]
+      params.permit(*policy(record).permitted_attributes)
+    else
+      params.require(name).permit(*policy(record).permitted_attributes)
+    end
   end
 
   def policies

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -343,6 +343,13 @@ describe Pundit do
       expect(Controller.new(user, params).permitted_attributes(post)).to eq({ 'title' => 'Hello', 'votes' => 5 })
       expect(Controller.new(double, params).permitted_attributes(post)).to eq({ 'votes' => 5 })
     end
+
+    it "checks policy for permitted attributes without requiring root node" do
+      params = ActionController::Parameters.new({ action: 'update', title: 'Hello', votes: 5, admin: true })
+
+      expect(Controller.new(user, params).permitted_attributes(post, no_root: true)).to eq({ 'title' => 'Hello', 'votes' => 5 })
+      expect(Controller.new(double, params).permitted_attributes(post, no_root: true)).to eq({ 'votes' => 5 })
+    end
   end
 
   describe "Pundit::NotAuthorizedError" do


### PR DESCRIPTION
This pull request is in reference to #298.

It's my first open source contribution, so please let me know if I did anything dumb or not in line with the contribution guidelines.