### PR TITLE
add controller class to exception

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -102,11 +102,11 @@ module Pundit
   end
 
   def verify_authorized
-    raise AuthorizationNotPerformedError unless pundit_policy_authorized?
+    raise AuthorizationNotPerformedError.new(self.class) unless pundit_policy_authorized?
   end
 
   def verify_policy_scoped
-    raise PolicyScopingNotPerformedError unless pundit_policy_scoped?
+    raise PolicyScopingNotPerformedError.new(self.class) unless pundit_policy_scoped?
   end
 
   def authorize(record, query=nil)


### PR DESCRIPTION
hey!

this adds the controller class to AuthorizationNotPerformedError and PolicyScopingNotPerformedError, to allow better debugging capabilities. this helped me a lot to identify the controller much quicker.

this changes to output from:
```
Failures:

  1) Access organization builds Manager sees organization projects in navigation dropdown
     Failure/Error: @organization = given_an_organization
     Pundit::AuthorizationNotPerformedError:
       OrganizationsController
     # ./lib/codeship/request_id.rb:29:in `call'
     # ./spec/support/features/organizations_helpers.rb:39:in `block in when_user_clicks_on_create_new_organization_link'
     # ./spec/support/features/organizations_helpers.rb:37:in `when_user_clicks_on_create_new_organization_link'
     # ./spec/support/features/organizations_helpers.rb:21:in `given_an_organization'
     # ./spec/acceptance/access_organization_builds_spec.rb:8:in `block (2 levels) in <top (required)>'
```

to

```
Failures:

  1) Access organization builds Contributor sees filtered organization projects in navigation dropdown
     Failure/Error: @organization = given_an_organization
     Pundit::AuthorizationNotPerformedError:
       Pundit::AuthorizationNotPerformedError
     # ./lib/codeship/request_id.rb:29:in `call'
     # ./spec/support/features/organizations_helpers.rb:39:in `block in when_user_clicks_on_create_new_organization_link'
     # ./spec/support/features/organizations_helpers.rb:37:in `when_user_clicks_on_create_new_organization_link'
     # ./spec/support/features/organizations_helpers.rb:21:in `given_an_organization'
     # ./spec/acceptance/access_organization_builds_spec.rb:8:in `block (2 levels) in <top (required)>'
```