### PR TITLE
Added collection_authorizable method

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -61,6 +61,20 @@ module Pundit
     def policy!(user, record)
       PolicyFinder.new(record).policy!.new(user, record)
     end
+
+    def collection_authorizable(collection, klass)
+      collection.instance_exec(klass) do |_klass|
+        @_policy_klass = _klass
+        def self.policy_class
+          @_policy_klass
+        end
+        def all
+          self
+        end
+      end
+      collection
+    end
+
   end
 
   module Helper
@@ -154,6 +168,10 @@ module Pundit
 
   def pundit_user
     current_user
+  end
+
+  def collection_authorizable(collection, policy_class)
+    Pundit.collection_authorizable(collection, policy_class)
   end
 
 private

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -351,4 +351,21 @@ describe Pundit do
       expect(error.message).to eq "must be logged in"
     end
   end
+
+  describe ".collection_authorizable" do
+    before :each do
+      @result = Pundit.collection_authorizable([1,2], String)
+    end
+
+    it "returns object with policy_scope method" do
+      expect(@result.policy_class).to eq String
+      expect(@result.class).to eq Array
+    end
+
+    it "returns object with all method" do
+      expect(@result.all).to eq @result
+      expect(@result.class).to eq Array
+    end
+  end
+
 end


### PR DESCRIPTION
In some cases I need to be able to authorize plain array of objects with some policy (for index action, for example). You have to define `policy_class` method on it. This PR adds helper method to do this.
```ruby
def index
  @collection = collection_authorizable [1,2,3], SomePolicy
  authorize @collection #will use SomePolicy class
end
```