### PR TITLE
ApplicationPolicy template: better defaults for edition/creation

### DIFF
--- a/lib/generators/pundit/install/templates/application_policy.rb
+++ b/lib/generators/pundit/install/templates/application_policy.rb
@@ -15,7 +15,7 @@ class ApplicationPolicy
   end
 
   def create?
-    false
+    new?
   end
 
   def new?
@@ -23,7 +23,7 @@ class ApplicationPolicy
   end
 
   def update?
-    false
+    edit?
   end
 
   def edit?


### PR DESCRIPTION
It's good to force policies to define e.g. either `new?` or `create?`, else bugs can happen.