### PR TITLE
Update example of :verify_authorized

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ forgotten to authorize the action. For example:
 
 ``` ruby
 class ApplicationController < ActionController::Base
-  after_action :verify_authorized, :except => :index
+  after_action :verify_authorized
 end
 ```
 
@@ -205,6 +205,7 @@ authorize individual instances.
 
 ``` ruby
 class ApplicationController < ActionController::Base
+  after_action :verify_authorized, :except => :index
   after_action :verify_policy_scoped, :only => :index
 end
 ```


### PR DESCRIPTION
## Why is this change necessary?

- Make the example more newbie friendly.
- I saw one of my colleagues copied and pasted this code snippet but
didn’t notice that the verification for index was totally off.
- Sometimes it's not really newbie. Doing things in rush, which happen to many companies, can also lead to this kind of problems.
- Official README is widely trusted. It will be great if we can make it
more newbie friendly.

## How does it address the issue?

- Remove `except` option from `verify_authorized` example.
- Add `before_action :verify_authorized` to `verify_policy_scoped`
example to complete a scenario.