### PR TITLE
Add YARD docs for Pundit::PolicyFinder

### DIFF
--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -1,17 +1,40 @@
 module Pundit
+  # Finds policy and scope classes for given object.
+  # @api public
+  # @example
+  #   user = User.find(params[:id])
+  #   finder = PolicyFinder.new(user)
+  #   finder.policy #=> UserPolicy
+  #   finder.scope #=> UserPolicy::Scope
+  #
   class PolicyFinder
     attr_reader :object
 
+    # @param object [any]
+    #
     def initialize(object)
       @object = object
     end
 
+    # @return [nil, Scope{#resolve}]
+    # @see https://github.com/elabs/pundit#scopes
+    # @example
+    #   scope = finder.scope #=> UserPolicy::Scope
+    #   scope.resolve #=> <#ActiveRecord::Relation ...>
+    #
     def scope
       policy::Scope if policy
     rescue NameError
       nil
     end
 
+    # @return [nil, Class] policy class with query methods
+    # @see https://github.com/elabs/pundit#policies
+    # @example
+    #   policy = finder.policy #=> UserPolicy
+    #   policy.show? #=> true
+    #   policy.update? #=> false
+    #
     def policy
       klass = find
       klass = klass.constantize if klass.is_a?(String)
@@ -20,11 +43,17 @@ module Pundit
       nil
     end
 
+    # @return [Scope{#resolve}]
+    # @raise [NotDefinedError] if scope could not be determined
+    #
     def scope!
       raise NotDefinedError, "unable to find policy scope of nil" if object.nil?
       scope or raise NotDefinedError, "unable to find scope `#{find}::Scope` for `#{object.inspect}`"
     end
 
+    # @return [Class] policy class with query methods
+    # @raise [NotDefinedError] if policy could not be determined
+    #
     def policy!
       raise NotDefinedError, "unable to find policy of nil" if object.nil?
       policy or raise NotDefinedError, "unable to find policy `#{find}` for `#{object.inspect}`"
@@ -32,6 +61,9 @@ module Pundit
 
   private
 
+    # @return [String] policy class name
+    # @api public
+    #
     def find
       if object.nil?
         nil


### PR DESCRIPTION
`Pundit::PolicyFinder` documented with YARD comments.

But I'm not sure if `PolicyFinder` and `PolicyFinder#find` is intended to be public interface. 
So I decided to clarify it using YARD tags (`@api public`). 
