### PR TITLE
use record#to_s in NotAuthorizedError#to_s and record#inspect in NotAuthorizedError#inspect

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -28,11 +28,16 @@ module Pundit
         @query  = options[:query]
         @record = options[:record]
         @policy = options[:policy]
+        @inspect = "#<#{self.class}: not allowed to #{query} this #{record.inspect}>"
 
-        message = options.fetch(:message) { "not allowed to #{query} this #{record.inspect}" }
+        message = options.fetch(:message) { "not allowed to #{query} this #{record || "nil"}" }
       end
 
       super(message)
+    end
+
+    def inspect
+      @inspect || super
     end
   end
 

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -17,23 +17,28 @@ describe Pundit do
   let(:avatar_four_five_six) { ProjectOneTwoThree::AvatarFourFiveSix.new }
 
   describe ".authorize" do
+    # rubocop:disable Style/MultilineBlockChain
     it "infers the policy and authorizes based on it" do
       expect(Pundit.authorize(user, post, :update?)).to be_truthy
     end
 
     it "works with anonymous class policies" do
       expect(Pundit.authorize(user, article_tag, :show?)).to be_truthy
-      expect { Pundit.authorize(user, article_tag, :destroy?) }.to raise_error(Pundit::NotAuthorizedError)
+      expect do
+        Pundit.authorize(user, article_tag, :destroy?)
+      end.to raise_error(Pundit::NotAuthorizedError, "not allowed to destroy? this article tag") do |error|
+        expect(error.inspect).to match(/not allowed to destroy\? this #<ArticleTag:0x.+>/)
+      end
     end
 
     it "raises an error with a query and action" do
-      # rubocop:disable Style/MultilineBlockChain
       expect do
         Pundit.authorize(user, post, :destroy?)
-      end.to raise_error(Pundit::NotAuthorizedError, "not allowed to destroy? this #<Post>") do |error|
+      end.to raise_error(Pundit::NotAuthorizedError, "not allowed to destroy? this Post") do |error|
         expect(error.query).to eq :destroy?
         expect(error.record).to eq post
         expect(error.policy).to eq Pundit.policy(user, post)
+        expect(error.inspect).to eq "#<Pundit::NotAuthorizedError: not allowed to destroy? this #<Post>>"
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -135,6 +135,17 @@ class ArticleTag
   def self.policy_class
     ArticleTagOtherNamePolicy
   end
+
+  def to_s
+    "article tag"
+  end
+
+  # jruby fallbacks to present #to_s unless #inspect defined
+  if RUBY_PLATFORM == "java"
+    def inspect
+      "#<ArticleTag:0x#{rand(10**8)}>"
+    end
+  end
 end
 
 class CriteriaPolicy < Struct.new(:user, :criteria); end


### PR DESCRIPTION
I read the https://github.com/elabs/pundit/pull/200 but I think, that `Exception#message` and `Exception#to_s` shouldn't include any sensible data

Imagine you're denying show? for some some record, but the error is getting rendered via #to_s somewhere => protected data will be exposed to anyone

Of course, rendering plain exception message to the end user is not the best idea,
but I think that default behaviour should protect anyone from such error.

This PR makes errors both:
- programmer-friendly as REPL uses #inspect when printing objects
- rendering-friendly, as record#to_s shouldn't include sensible data by design (as mentioned in #200)