### PR TITLE
Update README's Rescuing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,10 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+Alternatively, you can globally handle Pundit::NotAuthorizedError's by having rails handle them as a 403 error and serving a 403 error page. Add the following to application.rb:
+
+```config.action_dispatch.rescue_responses["Pundit::NotAuthorizedError"] = :forbidden```
+
 ## Creating custom error messages
 
 `NotAuthorizedError`s provide information on what query (e.g. `:create?`), what


### PR DESCRIPTION
I thought it worth mentioning this alternate approach to handling Pundit's NotAuthorized exception. With this approach the exception is handled by rails and the appropriate 403.html or dynamic generated error page is served.