### PR TITLE
Include Pundit module in controller examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ forgotten to authorize the action. For example:
 
 ``` ruby
 class ApplicationController < ActionController::Base
+  include Pundit
   after_action :verify_authorized
 end
 ```
@@ -295,6 +296,7 @@ authorize individual instances.
 
 ``` ruby
 class ApplicationController < ActionController::Base
+  include Pundit
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
 end


### PR DESCRIPTION
* In order for the `verify_authorized` and `verify_policy_scoped` methods to be defined in your controllers, you must `include Pundit`. This is stated early in the documentation, but it's not clear in these particular examples that it's needed.