### PR TITLE
Replace calls to `hide_action` with protected access modifier

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -128,22 +128,9 @@ module Pundit
       helper_method :pundit_policy_scope
       helper_method :pundit_user
     end
-    if respond_to?(:hide_action)
-      hide_action :policy
-      hide_action :policy_scope
-      hide_action :policies
-      hide_action :policy_scopes
-      hide_action :authorize
-      hide_action :verify_authorized
-      hide_action :verify_policy_scoped
-      hide_action :permitted_attributes
-      hide_action :pundit_user
-      hide_action :skip_authorization
-      hide_action :skip_policy_scope
-      hide_action :pundit_policy_authorized?
-      hide_action :pundit_policy_scoped?
-    end
   end
+
+protected
 
   # @return [Boolean] whether authorization has been performed, i.e. whether
   #                   one {#authorize} or {#skip_authorization} has been called

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -153,6 +153,8 @@ end
 
 class Controller
   include Pundit
+  # Mark protected methods public so they may be called in test
+  public(*Pundit.protected_instance_methods)
 
   attr_reader :current_user, :params
 


### PR DESCRIPTION
Curiosity got the best of me. After [striking up a conversation](https://github.com/elabs/pundit/pull/23#issuecomment-178278622) about `hide_action`, I decided to read up a little more about it in Rails. As it turns out, this feature [has been removed](https://github.com/rails/rails/pull/18371) from Rails master (Rails 5 beta). In order to maintain compatibility with future versions of Rails, I'm proposing that the use of `hide_action` be replaced with access modifiers in Pundit.

A couple things:

* Using `protected` over `private` so that subclasses of the including class may still access these methods.
* Since these methods are called directly in test, we raise the access modifier to public for the test object to preserve the test behavior.

### Concerns

1. Technically this changes the public API of the library. Arguably, it was never intended for these methods to be used outside of the object's including Pundit, but it's possible. Therefore, this is a breaking change (but maybe a "safeish" one :innocent:).
2. The tests that include a `Controller` feel somewhat misleading. The truth is, this is the public API of Pundit, but it should be internal to the including object...

I wanted to avoid large changes to the test suite and code for this proposal. Perhaps with some discussion, we can find a satisfactory solution :smiley_cat: 