### PR TITLE
use new ruby syntax for install generator

### DIFF
--- a/lib/generators/pundit/install/templates/application_policy.rb
+++ b/lib/generators/pundit/install/templates/application_policy.rb
@@ -11,7 +11,7 @@ class ApplicationPolicy
   end
 
   def show?
-    scope.where(:id => record.id).exists?
+    scope.where(id: record.id).exists?
   end
 
   def create?


### PR DESCRIPTION
Rubocop was showing a warning to use the new ruby syntax