### PR TITLE
Add splat lost in merge

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -243,7 +243,7 @@ protected
     else
       "permitted_attributes"
     end
-    params.require(param_key).permit(policy.public_send(method_name))
+    params.require(param_key).permit(*policy.public_send(method_name))
   end
 
   # Cache of policies. You should not rely on this method.


### PR DESCRIPTION
In order versions of rails it wasn't possible to pass an array to `permit`, which is what `permitted_attributes` [returns](https://github.com/elabs/pundit/blob/master/lib/pundit.rb#L246).

In reference to: https://github.com/elabs/pundit/issues/353