### PR TITLE
Add documentation for defining policy_class instance method

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,16 @@ class Post
 end
 ```
 
+You can also explicitly declare which policy to use for a specific instance of a class.
+
+```ruby
+class Post
+  def policy_class
+    published? ? PublishedPostPolicy : PostPolicy
+  end
+end
+```
+
 ## Just plain old Ruby
 
 As you can see, Pundit doesn't do anything you couldn't have easily done


### PR DESCRIPTION
I encountered a use case which required me to to define `policy_class` for instances of a class and had to do a little digging to make sure that I was able to do so. I thought it would be useful for other users of Pundit to see this feature via the documentation. 