### PR TITLE
Fixes namespace handling for policy_scope

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -88,7 +88,8 @@ module Pundit
     # @raise [NotDefinedError] if the policy scope cannot be found
     # @return [Scope{#resolve}] instance of scope class which can resolve to a scope
     def policy_scope!(user, scope)
-      PolicyFinder.new(scope).scope!.new(user, scope).resolve
+      model = scope.is_a?(Array) ? scope.last : scope
+      PolicyFinder.new(scope).scope!.new(user, model).resolve
     end
 
     # Retrieves the policy for the given record.

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -87,7 +87,7 @@ describe Pundit do
       end.to raise_error(Pundit::NotDefinedError, "unable to find policy scope of nil")
     end
 
-    it "returns an instantiated policy scope given an array of a symbol and plain model class", focus: true do
+    it "returns an instantiated policy scope given an array of a symbol and plain model class" do
       expect(Pundit.policy_scope!(user, [:project, Post])).to eq :read
     end
 

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -86,6 +86,14 @@ describe Pundit do
         Pundit.policy_scope!(user, nil)
       end.to raise_error(Pundit::NotDefinedError, "unable to find policy scope of nil")
     end
+
+    it "returns an instantiated policy scope given an array of a symbol and plain model class", focus: true do
+      expect(Pundit.policy_scope!(user, [:project, Post])).to eq :read
+    end
+
+    it "returns an instantiated policy scope given an array of a symbol and active model class" do
+      expect(Pundit.policy_scope!(user, [:project, Comment])).to eq Comment
+    end
   end
 
   describe ".policy" do
@@ -138,7 +146,7 @@ describe Pundit do
       policy = Pundit.policy(user, [:project, comment])
       expect(policy.class).to eq Project::CommentPolicy
       expect(policy.user).to eq user
-      expect(policy.post).to eq [:project, comment]
+      expect(policy.comment).to eq [:project, comment]
     end
 
     it "returns an instantiated policy given an array of a symbol and a plain model class" do
@@ -152,7 +160,7 @@ describe Pundit do
       policy = Pundit.policy(user, [:project, Comment])
       expect(policy.class).to eq Project::CommentPolicy
       expect(policy.user).to eq user
-      expect(policy.post).to eq [:project, Comment]
+      expect(policy.comment).to eq [:project, Comment]
     end
 
     it "returns correct policy class for an array of a multi-word symbols" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,10 @@ class Post < Struct.new(:user)
     :published
   end
 
+  def self.read
+    :read
+  end
+
   def to_s
     "Post"
   end
@@ -140,9 +144,23 @@ end
 class CriteriaPolicy < Struct.new(:user, :criteria); end
 
 module Project
-  class CommentPolicy < Struct.new(:user, :post); end
+  class CommentPolicy < Struct.new(:user, :comment)
+    class Scope < Struct.new(:user, :scope)
+      def resolve
+        scope
+      end
+    end
+  end
+
   class CriteriaPolicy < Struct.new(:user, :criteria); end
-  class PostPolicy < Struct.new(:user, :post); end
+
+  class PostPolicy < Struct.new(:user, :post)
+    class Scope < Struct.new(:user, :scope)
+      def resolve
+        scope.read
+      end
+    end
+  end
 end
 
 class DenierPolicy < Struct.new(:user, :record)


### PR DESCRIPTION
As discussed here https://github.com/elabs/pundit/issues/351 this fixes the policy_scope finder to work with namespaces.