### PR TITLE
don't let `include Pundit` override existing definition of `pundit_user`

### DIFF
--- a/lib/pundit.rb
+++ b/lib/pundit.rb
@@ -266,6 +266,7 @@ protected
   # @see https://github.com/elabs/pundit#customize-pundit-user
   # @return [Object] the user object to be used with pundit
   def pundit_user
+    return super if defined?(super)
     current_user
   end
 

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -385,6 +385,28 @@ describe Pundit do
     it "returns the same thing as current_user" do
       expect(controller.pundit_user).to eq controller.current_user
     end
+
+    it "is not overridden if defined before including Pundit" do
+      wrapper_module = Module.new do
+        extend ActiveSupport::Concern
+
+        included do
+          include Pundit
+        end
+
+        def pundit_user
+          "Thomas Friedman"
+        end
+      end
+
+      controller_class = Class.new do
+        include wrapper_module
+      end
+
+      pundit_user = controller_class.new.send(:pundit_user)
+
+      expect(pundit_user).to eq "Thomas Friedman"
+    end
   end
 
   describe "#policy" do


### PR DESCRIPTION
I ran into this issue when trying to create a wrapper module to Pundit that I included in certain of my controllers where I didn't have access to a `current_user`, and there was a different session-specific object I needed to pass to Pundit instead. The docs suggested I should define `pundit_user` for this purpose, so I did, but it was never called because including Pundit actually overrode my definition of it (based on the module `include` ordering).

This updates the default definition of `pundit_user` to call the existing method if it's defined.
