### PR TITLE
Allow specification of a NilClassPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,27 @@ class ApplicationPolicy
 end
 ```
 
+## NilClassPolicy
+
+To support a [null object pattern](https://en.wikipedia.org/wiki/Null_Object_pattern)
+you may find that you want to implement a `NilClassPolicy`. This might be useful
+where you want to extend your ApplicationPolicy to allow some tolerance of, for
+example, associations which might be `nil`.
+
+```ruby
+class NilClassPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      raise Pundit::NotDefinedError, "Cannot scope NilClass"
+    end
+  end
+
+  def show?
+    false # Nobody can see nothing
+  end
+end
+```
+
 ## Rescuing a denied Authorization in Rails
 
 Pundit raises a `Pundit::NotAuthorizedError` you can

--- a/lib/pundit/policy_finder.rb
+++ b/lib/pundit/policy_finder.rb
@@ -47,7 +47,6 @@ module Pundit
     # @raise [NotDefinedError] if scope could not be determined
     #
     def scope!
-      raise NotDefinedError, "unable to find policy scope of nil" if object.nil?
       scope or raise NotDefinedError, "unable to find scope `#{find}::Scope` for `#{object.inspect}`"
     end
 
@@ -55,7 +54,6 @@ module Pundit
     # @raise [NotDefinedError] if policy could not be determined
     #
     def policy!
-      raise NotDefinedError, "unable to find policy of nil" if object.nil?
       policy or raise NotDefinedError, "unable to find policy `#{find}` for `#{object.inspect}`"
     end
 
@@ -74,9 +72,7 @@ module Pundit
   private
 
     def find
-      if object.nil?
-        nil
-      elsif object.respond_to?(:policy_class)
+      if object.respond_to?(:policy_class)
         object.policy_class
       elsif object.class.respond_to?(:policy_class)
         object.class.policy_class

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -59,8 +59,8 @@ describe Pundit do
       expect(Pundit.policy_scope(user, Article)).to be_nil
     end
 
-    it "returns nil if blank object given" do
-      expect(Pundit.policy_scope(user, nil)).to be_nil
+    it "raises an exception if nil object given" do
+      expect { Pundit.policy_scope(user, nil) }.to raise_error(Pundit::NotDefinedError)
     end
   end
 
@@ -84,7 +84,7 @@ describe Pundit do
     it "throws an exception if the given policy scope is nil" do
       expect do
         Pundit.policy_scope!(user, nil)
-      end.to raise_error(Pundit::NotDefinedError, "unable to find policy scope of nil")
+      end.to raise_error(Pundit::NotDefinedError, "Cannot scope NilClass")
     end
   end
 
@@ -205,8 +205,8 @@ describe Pundit do
       expect(Pundit.policy(user, Article)).to be_nil
     end
 
-    it "returns nil if the given policy is nil" do
-      expect(Pundit.policy(user, nil)).to be_nil
+    it "returns the specified NilClassPolicy for nil" do
+      expect(Pundit.policy(user, nil)).to be_a NilClassPolicy
     end
 
     describe "with .policy_class set on the model" do
@@ -280,8 +280,8 @@ describe Pundit do
       expect { Pundit.policy!(user, Article) }.to raise_error(Pundit::NotDefinedError)
     end
 
-    it "throws an exception if the given policy is nil" do
-      expect { Pundit.policy!(user, nil) }.to raise_error(Pundit::NotDefinedError, "unable to find policy of nil")
+    it "returns the specified NilClassPolicy for nil" do
+      expect(Pundit.policy!(user, nil)).to be_a NilClassPolicy
     end
   end
 
@@ -359,7 +359,7 @@ describe Pundit do
     end
 
     it "raises an error when the given record is nil" do
-      expect { controller.authorize(nil, :destroy?) }.to raise_error(Pundit::NotDefinedError)
+      expect { controller.authorize(nil, :destroy?) }.to raise_error(Pundit::NotAuthorizedError)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -162,15 +162,19 @@ class Controller
   end
 end
 
-class NilClassPolicy
+class NilClassPolicy < Struct.new(:user, :record)
   class Scope
     def initialize(*)
-      raise "I'm only here to be annoying!"
+      raise Pundit::NotDefinedError, "Cannot scope NilClass"
     end
   end
 
-  def initialize(*)
-    raise "I'm only here to be annoying!"
+  def show?
+    false
+  end
+
+  def destroy?
+    false
   end
 end
 


### PR DESCRIPTION
This saves having to check whether objects are nil before checking their
policy.

This contradicts the intent of elabs/pundit#251 and could represent a
breaking change for some.

@jnicklas I hope you'll consider my reasoning here - I am using this branch in a project for checking permissions on associations which can legitimately be nil.