### PR TITLE
WIP Fix Bundle on CI

### DIFF
--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -22,9 +22,10 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "activemodel", ">= 3.0.0"
   gem.add_development_dependency "actionpack", ">= 3.0.0"
   gem.add_development_dependency "bundler", "~> 1.3"
-  gem.add_development_dependency "rspec", ">=2.0.0"
+  gem.add_development_dependency "rspec", ">= 2.0.0"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake"
+  gem.add_development_dependency "rack", "~> 1.6"
   gem.add_development_dependency "yard"
-  gem.add_development_dependency "rubocop"
+  gem.add_development_dependency "rubocop", "0.41.2"
 end


### PR DESCRIPTION
It looks like JRuby and Rubinius builds have been failing on CI for a couple months because bundler couldn't install some gems.

I think something might be up with currently with Travis, because now I am unable to install any version of Rubinius, even on [https://travis-ci.org/elabs/pundit/jobs/163589746](other branches) that didn't have this problem yesterday. I did get everything else to work by locking down some versions.

I'm going to try and rebuild it again tomorrow to see if the remaining issue is just an intermittent travis/rvm thing.
