### PR TITLE
Add #authorize_with to allow specifying a policy class

### DIFF
--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Pundit do
-  let(:user) { double }
+  let(:user) { double(moderator?: false) }
   let(:post) { Post.new(user) }
   let(:customer_post) { Customer::Post.new(user) }
   let(:post_four_five_six) { PostFourFiveSix.new(user) }
@@ -365,6 +365,16 @@ describe Pundit do
     it "raises an error when the given record is nil" do
       expect { controller.authorize(nil, :destroy?) }.to raise_error(Pundit::NotDefinedError)
     end
+  end
+
+  describe "#authorize_with" do
+
+    it "uses the policy specified" do
+      expect {
+        controller.authorize_with(post, policy_class: PostModerationPolicy)
+      }.to raise_error(Pundit::NotAuthorizedError)
+    end
+
   end
 
   describe "#skip_authorization" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,6 +57,14 @@ class PostPolicy < Struct.new(:user, :post)
   end
 end
 
+class PostModerationPolicy < PostPolicy
+
+  def update?
+    user.moderator?
+  end
+
+end
+
 class Post < Struct.new(:user)
   def self.published
     :published


### PR DESCRIPTION
For example, if both PostsController and PostModerationsController need
to check permission on Post, and different rules apply in each case,
PostModerationsController can call:

    authorize_with(record, policy_class: PostModerationPolicy)

I'm not sure if this is a feature you want, and if so, I'm happy to tweak the implementation and/or tests as you like.

Right now I have a use case where the same record is used in different controllers because the record is essentially a message: a `StaffingRequest` is created in the `StaffingRequestsController`, and in `StaffingRequestAssignmentsController`, different users assign a worker to that `StaffingRequest`.

I think you already support finding a different policy depending on namespace, but `Assignments::StaffingRequestsController` didn't seem like a good name, and it seemed pretty extreme to namespace my controller solely for the benefit of `authorize`.

My current workaround is to re-implement `authorize` in that controller, instantiating the policy I want, but it means I have to do stuff like `@_pundit_policy_authorized = true` myself, which seems pretty hacky.

So my options were:

1. Namespace my controller solely for the benefit of `authorize`
2. Re-implement `authorize` myself so that it can use the policy class I want
3. Add a version of `authorize` to Pundit that can be told what policy class to use

3 seemed like the best choice.