### PR TITLE
CI against Ruby 2.2.8/2.3.5/2.4.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 1.9
+  TargetRubyVersion: 2.0
   Exclude:
     - "gemfiles/**/*"
     - "vendor/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 2.1
   Exclude:
     - "gemfiles/**/*"
     - "vendor/**/*"
@@ -34,7 +34,7 @@ Metrics/PerceivedComplexity:
 Style/StructInheritance:
   Enabled: false
 
-Style/AlignParameters:
+Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
 Style/StringLiterals:
@@ -43,7 +43,7 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
-Style/ClosingParenthesisIndentation:
+Layout/ClosingParenthesisIndentation:
   Enabled: false
 
 Style/OneLineConditional:
@@ -58,7 +58,7 @@ Style/Not:
 Documentation:
   Enabled: false # TODO: Enable again once we have more docs
 
-Style/CaseIndentation:
+Layout/CaseIndentation:
   EnforcedStyle: case
   SupportedStyles:
     - case
@@ -70,13 +70,13 @@ Style/PercentLiteralDelimiters:
     '%w': "[]"
     '%W': "[]"
 
-Style/AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
 
 Style/SignalException:
   Enabled: false
 
-Style/IndentationWidth:
+Layout/IndentationWidth:
   Enabled: false
 
 Style/TrivialAccessors:
@@ -97,7 +97,7 @@ Style/SpecialGlobalVars:
 Style/TrivialAccessors:
   Enabled: false
 
-Style/IndentHash:
+Layout/IndentHash:
   Enabled: false
 
 Style/DoubleNegation:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
     - rvm: 2.2.8
     - rvm: 2.3.5
     - rvm: 2.4.2
-    - rvm: jruby-1.7.26
       env:
         - JRUBY_OPTS="--debug"
     - rvm: jruby-9.1.8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ before_install:
 
 matrix:
   include:
-    - rvm: 2.4.1
+    - rvm: 2.4.2
       script: bundle exec rake rubocop # ONLY lint once, first
     - rvm: 2.1
-    - rvm: 2.2.7
-    - rvm: 2.3.4
-    - rvm: 2.4.1
+    - rvm: 2.2.8
+    - rvm: 2.3.5
+    - rvm: 2.4.2
     - rvm: jruby-1.7.26
       env:
         - JRUBY_OPTS="--debug"

--- a/pundit.gemspec
+++ b/pundit.gemspec
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "pundit/version"

--- a/spec/pundit_spec.rb
+++ b/spec/pundit_spec.rb
@@ -121,10 +121,10 @@ describe Pundit do
     end
 
     it "returns an instantiated policy given an array of symbols" do
-      policy = Pundit.policy(user, [:project, :criteria])
+      policy = Pundit.policy(user, %i[project criteria])
       expect(policy.class).to eq Project::CriteriaPolicy
       expect(policy.user).to eq user
-      expect(policy.criteria).to eq [:project, :criteria]
+      expect(policy.criteria).to eq %i[project criteria]
     end
 
     it "returns an instantiated policy given an array of a symbol and plain model instance" do
@@ -156,7 +156,7 @@ describe Pundit do
     end
 
     it "returns correct policy class for an array of a multi-word symbols" do
-      policy = Pundit.policy(user, [:project_one_two_three, :criteria_four_five_six])
+      policy = Pundit.policy(user, %i[project_one_two_three criteria_four_five_six])
       expect(policy.class).to eq ProjectOneTwoThree::CriteriaFourFiveSixPolicy
     end
 
@@ -269,10 +269,10 @@ describe Pundit do
     end
 
     it "returns an instantiated policy given an array of symbols" do
-      policy = Pundit.policy!(user, [:project, :criteria])
+      policy = Pundit.policy!(user, %i[project criteria])
       expect(policy.class).to eq Project::CriteriaPolicy
       expect(policy.user).to eq user
-      expect(policy.criteria).to eq [:project, :criteria]
+      expect(policy.criteria).to eq %i[project criteria]
     end
 
     it "throws an exception if the given policy can't be found" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ class PostPolicy < Struct.new(:user, :post)
 
   def permitted_attributes
     if post.user == user
-      [:title, :votes]
+      %i[title votes]
     else
       [:votes]
     end


### PR DESCRIPTION
This PR includes deletion of unnecessary magic comment.

Details here:
* [Ruby 2.0.0-p0 is released](https://www.ruby-lang.org/en/news/2013/02/24/ruby-2-0-0-p0-is-released/)

> The UTF-8 default encoding, which make many magic comments omissible

Another change is `TargetRubyVersion` to 2.1.
Otherwise, [an error will occur.](https://travis-ci.org/elabs/pundit/jobs/289815135)
The version supported by rubocop is 2.1 or higher

ruby 1.9.3 and 2.0 has already been dropped
https://github.com/elabs/pundit/commit/0569b065d709c42dc07a3aa9072d32395a0d5087
https://github.com/elabs/pundit/commit/f60d059df9523bfea9edc45ae4bf019b812

Therefore, I think that jruby1.7 can be dropped.
https://travis-ci.org/elabs/pundit/jobs/291342098